### PR TITLE
Remove external mod references in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 # Fantasy
  
- A collaboration between a small group of CDDA modders, Fantasy (name still being worked on), will be just what it sounds like, a fantasy world undergoing some decidedly rough times with lots of monsters rising up and making trouble. Adventures, quests, dungeons, you name it, it'll be in there.
- 
- Intended to be run alongside of XP and Magic Unbound to provide a much more RPGish experience.
+ A collaboration between a small group of CDDA modders, Fantasy (name still being worked on), will be just what it sounds like, a fantasy world undergoing some decidedly rough times with lots of monsters rising up and making trouble. Adventures, quests, dungeons, you name it, it'll be in there. 


### PR DESCRIPTION
Due to the outdated nature of both Magic Unbound and XP, I have opted to remove the references to them from the info file.